### PR TITLE
Satisfy io.Writer interface

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -38,14 +38,14 @@ func New(config Config) *Producer {
 }
 
 // Put record `data` using `partitionKey`. This method is thread-safe.
-func (p *Producer) Put(data []byte, partitionKey string) error {
+func (p *Producer) Write(data []byte) (int, error) {
 	if len(data) > maxRecordSize {
 		return ErrRecordSizeExceeded
 	}
 
 	p.records <- &k.PutRecordsRequestEntry{
 		Data:         data,
-		PartitionKey: &partitionKey,
+		PartitionKey: p.Config.PartitionKey(),
 	}
 
 	return nil


### PR DESCRIPTION
The goal of this PR is to be able to do this

```
stream := kinesis.New()
encoder := json.NewEncoder(stream)
```

So for that, we have to generate a partition via another way. Right now I'm just making a hash of the data being inserted. I could also generate a `uuid` the same way you do in your log package (as a default).

Could be worth it to keep the `Put` function just to be able to pass a specific partition key.
